### PR TITLE
Add setting to toggle ZMK modifier labels between text and symbols

### DIFF
--- a/src/overlay_window/settings_sync.rs
+++ b/src/overlay_window/settings_sync.rs
@@ -15,7 +15,8 @@ impl OverlayApp {
             || self.settings.active.margin != self.settings.draft.margin
             || self.settings.active.position != self.settings.draft.position
             || self.settings.active.timeout != self.settings.draft.timeout
-            || self.settings.active.theme != self.settings.draft.theme;
+            || self.settings.active.theme != self.settings.draft.theme
+            || self.settings.active.mod_label_style != self.settings.draft.mod_label_style;
 
         if !changed {
             return;
@@ -29,6 +30,7 @@ impl OverlayApp {
         self.settings.active.position = self.settings.draft.position;
         self.settings.active.timeout = self.settings.draft.timeout;
         self.settings.active.theme = self.settings.draft.theme.clone();
+        self.settings.active.mod_label_style = self.settings.draft.mod_label_style;
 
         if let AppConnectionState::Connected { keyboard } = &self.session.connection {
             if old_timeout != self.settings.active.timeout {

--- a/src/overlay_window/ui_overlay.rs
+++ b/src/overlay_window/ui_overlay.rs
@@ -1,8 +1,8 @@
 use super::state::LabelGalleys;
 use super::OverlayApp;
 use crate::keyboard::Keyboard;
-use crate::layout_key::{KeycodeKind, LayoutKey};
-use crate::settings::ThemeColor;
+use crate::layout_key::{KeycodeKind, Label, LayoutKey};
+use crate::settings::{ModLabelStyle, ThemeColor};
 use eframe::egui::{self, Window};
 
 impl OverlayApp {
@@ -21,6 +21,20 @@ impl OverlayApp {
         let fits_width =
             |galley: &std::sync::Arc<egui::Galley>, max: f32| galley.rect.width() <= max;
         let max_width = rect.width() * 0.85;
+
+        let key_owned;
+        let key: &LayoutKey =
+            if key.kind == KeycodeKind::Modifier && key.symbol.is_some() && !key.tap.is_empty() {
+                let mut k = key.clone();
+                match self.settings.active.mod_label_style {
+                    ModLabelStyle::Text => k.symbol = None,
+                    ModLabelStyle::Symbols => k.tap = Label::default(),
+                }
+                key_owned = k;
+                &key_owned
+            } else {
+                key
+            };
 
         if let Some(symbol) = &key.symbol {
             let symbol_font = egui::FontId::proportional(0.33 * size * font_scale);

--- a/src/overlay_window/ui_settings.rs
+++ b/src/overlay_window/ui_settings.rs
@@ -1,6 +1,6 @@
 use super::state::AppConnectionState;
 use super::OverlayApp;
-use crate::settings::WindowPosition;
+use crate::settings::{ModLabelStyle, WindowPosition};
 use eframe::egui::{self, Window};
 
 impl OverlayApp {
@@ -235,6 +235,21 @@ impl OverlayApp {
                                 &mut self.settings.draft.auto_fit_before_ellipsis,
                                 "Fit long labels to available space",
                             );
+                            ui.end_row();
+
+                            ui.label("Modifier labels");
+                            egui::ComboBox::from_id_salt("mod_label_style_combo")
+                                .width(ui.available_width())
+                                .selected_text(self.settings.draft.mod_label_style.to_string())
+                                .show_ui(ui, |ui| {
+                                    for style in [ModLabelStyle::Text, ModLabelStyle::Symbols] {
+                                        ui.selectable_value(
+                                            &mut self.settings.draft.mod_label_style,
+                                            style,
+                                            style.to_string(),
+                                        );
+                                    }
+                                });
                             ui.end_row();
                         });
                 });

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -85,6 +85,38 @@ impl FromStr for WindowPosition {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum ModLabelStyle {
+    #[default]
+    Text,
+    Symbols,
+}
+
+impl fmt::Display for ModLabelStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ModLabelStyle::Text => "Text",
+                ModLabelStyle::Symbols => "Symbols",
+            }
+        )
+    }
+}
+
+impl FromStr for ModLabelStyle {
+    type Err = ParseSettingsError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "Text" => Ok(ModLabelStyle::Text),
+            "Symbols" => Ok(ModLabelStyle::Symbols),
+            _ => Err(ParseSettingsError),
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ThemeColor {
     pub r: u8,
@@ -172,6 +204,7 @@ pub struct Settings {
     pub timeout: i64,
     pub margin: u32,
     pub theme: ThemeSettings,
+    pub mod_label_style: ModLabelStyle,
 }
 
 impl Default for Settings {
@@ -184,6 +217,7 @@ impl Default for Settings {
             timeout: 2000,
             margin: 10,
             theme: ThemeSettings::default(),
+            mod_label_style: ModLabelStyle::default(),
         }
     }
 }
@@ -243,6 +277,7 @@ impl Settings {
             section.set(format!("layer_color_{index}"), color.to_string());
         }
         section.set("font_color", self.theme.font_color.to_string());
+        section.set("mod_label_style", self.mod_label_style.to_string());
         conf.write_to_file(path)
     }
 
@@ -286,6 +321,11 @@ impl Settings {
         if let Some(val) = section.get("font_color") {
             if let Ok(parsed) = val.parse() {
                 s.theme.font_color = parsed;
+            }
+        }
+        if let Some(val) = section.get("mod_label_style") {
+            if let Ok(parsed) = val.parse() {
+                s.mod_label_style = parsed;
             }
         }
         Some(s)

--- a/src/zmk_keycode_labels/keycode_label.rs
+++ b/src/zmk_keycode_labels/keycode_label.rs
@@ -701,6 +701,7 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
         }),
         Keycode::LEFT_CONTROL => Some(LayoutKey {
             tap: Label::new("Ctrl"),
+            symbol: Some("\u{2388}".to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
@@ -712,6 +713,7 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
         }),
         Keycode::LEFT_ALT => Some(LayoutKey {
             tap: Label::new("Alt"),
+            symbol: Some(egui_phosphor::regular::OPTION.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
@@ -723,6 +725,7 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
         }),
         Keycode::RIGHT_CONTROL => Some(LayoutKey {
             tap: Label::new("Ctrl"),
+            symbol: Some("\u{2388}".to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
@@ -734,6 +737,7 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
         }),
         Keycode::RIGHT_ALT => Some(LayoutKey {
             tap: Label::new("Alt"),
+            symbol: Some(egui_phosphor::regular::OPTION.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),


### PR DESCRIPTION
## Problem

ZMK modifier keys render inconsistently across keycodes in `src/zmk_keycode_labels/keycode_label.rs`:

- `LEFT_CONTROL`, `RIGHT_CONTROL`, `LEFT_ALT`, `RIGHT_ALT` → text only (`Ctrl`, `Alt`)
- `LEFT_SHIFT`, `RIGHT_SHIFT`, `LEFT_COMMAND`, `RIGHT_COMMAND` → text + symbol side-by-side (`⇧ Shift`, ` Win`)

No way to pick one consistent style.

## Change

`ModLabelStyle` setting (`Text` | `Symbols`, default `Text`) controls how `KeycodeKind::Modifier` keys with both `tap` and `symbol` set are rendered. Persisted as `mod_label_style` in `settings.ini`. Exposed as a ComboBox in the Overlay Appearance section.

The renderer (`generate_key_label_galleys` in `src/overlay_window/ui_overlay.rs`) checks the setting at the top of the function and shadows `key` with a clone that has the inactive field cleared. Rest of the function is unchanged.

To make `Symbols` mode actually do something for Ctrl/Alt, this also assigns symbols to the four mod keycodes that previously had none: `\u{2388}` (⎈ helm) for Control, the existing `egui_phosphor::regular::OPTION` glyph (⌥) for Alt.

## Default behavior

Default `Text` matches current rendering for mods that had only text. Mods that previously rendered side-by-side (`Shift`, `Cmd`) now render as text only in the default — small visible change for those four keys.

## Tradeoffs / scope

- **Why not a third `Both` option?** Would preserve every keycode's current render exactly, but adds a flag that mainly papers over the prior inconsistency. Skipped; can be added if users miss the side-by-side look.
- **Why not QMK?** QMK's `mod_value_to_string` in `src/qmk_keycode_labels/advanced.rs` builds chord text like `MOD_LCTL | MOD_LSFT(A)`. Converting that to symbol form is a rewrite, not a thread-through. Left for a follow-up.
- **Why not per-mod configuration?** More surface area for marginal benefit. A two-mode toggle is the smallest thing that gives a consistent look.

## Test plan

- [x] `cargo build --release` clean on macOS arm64
- [x] App launches and stays up
- [ ] Open settings, find "Modifier labels" ComboBox under Overlay Appearance
- [ ] Switch to `Symbols` — connected keyboard mod keys render as ⎈ ⇧ ⌥ Win
- [ ] Switch back to `Text` — render as Ctrl Shift Alt Win
- [ ] Restart app — setting persists via `settings.ini`
- [ ] Verify mod-tap behavior (e.g. `&mt LSHIFT A`) — hold label switches with setting