### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/evaluate-nix.yml
+++ b/.github/workflows/evaluate-nix.yml
@@ -1,0 +1,24 @@
+name: evaluate-nix
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
+      - name: Check evaluation, also builds the package
+        run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ Session.vim
 .cargo
 # Included because it is part of the test case
 !/tests/run-make/thumb-none-qemu/example/.cargo
+.direnv
+.pre-commit-config.yaml
 
 ## Configuration
 /config.toml
@@ -54,6 +56,7 @@ build/
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+/result
 
 ## Temporary files
 *~

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,193 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779575509,
+        "narHash": "sha256-wXKYURZz76ZC5lbuDA1oVQA/MxSB3pSJ1raF1HG0oIc=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "831c50f4a4304068f125e603add6a8839f08b3eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": []
+      },
+      "locked": {
+        "lastModified": 1779790483,
+        "narHash": "sha256-2wCMtmVmkCcyHaH6hkrbx7XdUgLYP5E1wl/jc1YxxTY=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "6012e5463531342033571efe294ec880bf13dd95",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779694939,
+        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pre-commit": "pre-commit"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -124,21 +124,21 @@
         # Note that this is done as a separate derivation so that
         # we can block the CI if there are issues here, but not
         # prevent downstream consumers from building our crate by itself.
-        keypeek-clippy = craneLib.cargoClippy (commonArgs
-          // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-          });
+        #keypeek-clippy = craneLib.cargoClippy (commonArgs
+        #  // {
+        #    inherit cargoArtifacts;
+        #    cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+        #  });
 
-        keypeek-doc = craneLib.cargoDoc (commonArgs
-          // {
-            inherit cargoArtifacts;
-          });
+        #keypeek-doc = craneLib.cargoDoc (commonArgs
+        #  // {
+        #    inherit cargoArtifacts;
+        #  });
 
         # Check formatting
-        keypeek-fmt = craneLib.cargoFmt {
-          inherit src;
-        };
+        #keypeek-fmt = craneLib.cargoFmt {
+        #  inherit src;
+        #};
 
         # Audit dependencies
         #keypeek-audit = craneLib.cargoAudit {
@@ -163,10 +163,10 @@
         pre-commit-check = pre-commit.lib.${system}.run {
           src = ./.;
           hooks = {
-            editorconfig-checker.enable = true;
+            #editorconfig-checker.enable = true;
             alejandra.enable = true;
             deadnix.enable = true;
-            flake-checker.enable = true;
+            #flake-checker.enable = true;
             statix.enable = true;
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,202 @@
+{
+  description = "keypeek";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane.url = "github:ipetkov/crane";
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-analyzer-src.follows = "";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+
+    pre-commit = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    crane,
+    fenix,
+    flake-utils,
+    #advisory-db,
+    pre-commit,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      inherit (pkgs) lib;
+
+      libPath = with pkgs;
+        lib.makeLibraryPath [
+          libGL
+          libxkbcommon
+          wayland
+          libx11
+          libxcursor
+          libxi
+          libxrandr
+          libayatana-appindicator
+        ];
+
+      craneLib = crane.mkLib pkgs;
+      src = lib.cleanSourceWith {
+        src = ./.;
+        # filter out all non rust and still include resources
+        filter = path: type:
+          (builtins.match ".+-source/resources/.*$" path != null) || (craneLib.filterCargoSources path type);
+        name = "source";
+      };
+
+      # Common arguments can be set here to avoid repeating them later
+      commonArgs = {
+        inherit src;
+        strictDeps = false; # else openssl-sys fails
+
+        buildInputs = with pkgs; [
+          glib
+          dbus
+          atk
+          gdk-pixbuf
+          pango
+          gtk3
+          udev
+          xdotool
+          pkg-config
+
+          libxcb
+        ];
+
+        # Additional environment variables can be set directly
+        # MY_CUSTOM_VAR = "some value";
+      };
+
+      craneLibLLvmTools =
+        craneLib.overrideToolchain
+        (fenix.packages.${system}.stable.withComponents [
+          "cargo"
+          "llvm-tools"
+          "rustc"
+        ]);
+
+      # Build *just* the cargo dependencies, so we can reuse
+      # all of that work (e.g. via cachix) when running in CI
+      cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+      # Build the actual crate itself, reusing the dependency
+      # artifacts from above.
+      keypeek = craneLib.buildPackage (commonArgs
+        // {
+          inherit cargoArtifacts;
+        }
+        // {
+          nativeBuildInputs = [pkgs.makeWrapper];
+          postInstall = ''
+            wrapProgram "$out/bin/keypeek" --prefix LD_LIBRARY_PATH : "${libPath}"
+          '';
+        });
+    in {
+      checks = {
+        # Build the crate as part of `nix flake check` for convenience
+        inherit keypeek;
+
+        # Run clippy (and deny all warnings) on the crate source,
+        # again, reusing the dependency artifacts from above.
+        #
+        # Note that this is done as a separate derivation so that
+        # we can block the CI if there are issues here, but not
+        # prevent downstream consumers from building our crate by itself.
+        keypeek-clippy = craneLib.cargoClippy (commonArgs
+          // {
+            inherit cargoArtifacts;
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+
+        keypeek-doc = craneLib.cargoDoc (commonArgs
+          // {
+            inherit cargoArtifacts;
+          });
+
+        # Check formatting
+        keypeek-fmt = craneLib.cargoFmt {
+          inherit src;
+        };
+
+        # Audit dependencies
+        #keypeek-audit = craneLib.cargoAudit {
+        #  inherit src advisory-db;
+        #};
+
+        # Audit licenses
+        #keypeek-deny = craneLib.cargoDeny {
+        #  inherit src;
+        #};
+
+        # Run tests with cargo-nextest
+        # Consider setting `doCheck = false` on `keypeek` if you do not want
+        # the tests to run twice
+        keypeek-nextest = craneLib.cargoNextest (commonArgs
+          // {
+            inherit cargoArtifacts;
+            partitions = 1;
+            partitionType = "count";
+          });
+
+        pre-commit-check = pre-commit.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            editorconfig-checker.enable = true;
+            alejandra.enable = true;
+            deadnix.enable = true;
+            flake-checker.enable = true;
+            statix.enable = true;
+          };
+        };
+      };
+
+      packages =
+        {
+          default = keypeek;
+        }
+        // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+          keypeek-llvm-coverage = craneLibLLvmTools.cargoLlvmCov (commonArgs
+            // {
+              inherit cargoArtifacts;
+            });
+        };
+
+      apps.default = flake-utils.lib.mkApp {
+        drv = keypeek;
+      };
+
+      devShells.default = craneLib.devShell {
+        # Inherit inputs from checks.
+        checks = self.checks.${system};
+
+        # Additional dev-shell environment variables can be set directly
+        # MY_CUSTOM_DEVELOPMENT_VAR = "something else";
+        LD_LIBRARY_PATH = libPath;
+
+        # Extra inputs can be added here; cargo and rustc are provided by default.
+        packages = [];
+      };
+    });
+}


### PR DESCRIPTION
Add Nix flake

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/srwi/keypeek/blob/master/CONTRIBUTING.md)

## Summary

Allows easily using Keypeek on Nix and NixOS systems.

I want to use this software on my NixOS setup and encountered the issue that neither cargo run or the appimage worked.
My solution was to write a Nix build file for this project, this build file contains mostly boilerplate code to build a Rust project and all the required dependencies, the Rust crates are still only defined in the Cargo.toml.

I don't know if you are happy with merging this, especially if you might not want to maintain the build file.
If not I would still recommend to either keep this PR around as a draft PR or similar so that other users like myself can use and build upon this PR.

## Related issue

<!-- Link the issue discussed before this PR, for example: Fixes #123. If there is no issue, explain why. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] UI change
- [ ] Documentation update
- [x] Refactoring / maintenance

## Testing

The resulting build was tested on NixOS 25.11 with a Sway WM and using a Totem split keyboard with ZMK firmware.

## Screenshots or recordings

<!-- Add screenshots or recordings for visible UI changes. -->
